### PR TITLE
Add local database with Docker

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+POSTGRES_PASSWORD=changeme

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 venv
 node_modules
 website/dist
+.env

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,6 +27,13 @@ python fetch_data.py   # queries Overpass API per area, writes ../data/export.ge
 ```
 `fetch_data.py` has no CLI args — the list of OSM relation area IDs to query (Charlotte, Belmont, Cramerton, McAdenville) is hardcoded near the bottom of the file, as are the Overpass endpoint and retry/backoff behavior. Output is minified GeoJSON at `data/export.geojson`.
 
+### Database (`db/`)
+```
+cp .env.example .env       # first time only; sets POSTGRES_PASSWORD locally
+docker compose up db       # starts a PostGIS 16-3.4 container on localhost:5432
+```
+`.env` is gitignored — `docker compose up db` reads `POSTGRES_PASSWORD` from it. The named volume `pgdata` persists data across `docker compose down`/`up`. `db/init/` only runs on first boot against an empty volume (see `db/init/README.md`) — it is not a migration mechanism.
+
 There is no test suite for either the frontend or the pipeline.
 
 ## Architecture

--- a/db/init/0001_create_extension.sql
+++ b/db/init/0001_create_extension.sql
@@ -1,0 +1,3 @@
+-- Bootstraps the postgis extension on first container start.
+-- See db/init/README.md for why this directory holds only this.
+CREATE EXTENSION IF NOT EXISTS postgis;

--- a/db/init/README.md
+++ b/db/init/README.md
@@ -1,0 +1,14 @@
+# db/init/
+
+Scripts here are mounted read-only to `/docker-entrypoint-initdb.d` in the `db`
+compose service. The official Postgres/PostGIS image only runs this directory
+the **first** time a container starts against an empty data directory — it is
+a one-shot bootstrap, not a repeatable migration mechanism. Once the schema
+needs to evolve past its first version, ongoing changes go through an
+explicit migration step (see docs/planning/layers/persistence-layer.md §6),
+not this directory.
+
+For now it holds a single script that enables the `postgis` extension, so a
+freshly created database is immediately usable without a manual step. If a
+later story (e.g. an EF Core migration) takes over creating the extension
+itself, this file can be deleted — don't let both mechanisms try to own it.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,20 @@
+services:
+  db:
+    image: postgis/postgis:16-3.4
+    environment:
+      POSTGRES_DB: bikemap
+      POSTGRES_USER: bikemap
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+      - ./db/init:/docker-entrypoint-initdb.d:ro   # first-boot bootstrap only, see db/init/README.md
+    ports:
+      - "5432:5432"   # local dev convenience; not needed once the API talks to `db` over the compose network
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U bikemap -d bikemap"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+volumes:
+  pgdata:


### PR DESCRIPTION
## Summary
Sets up a local database (PostGIS/Postgres) that runs in Docker, as the first building block for the v2 multi-city migration. This lets the app store map data in a real database instead of a static file, which upcoming work builds on.

## What this gives us
- One command (`docker compose up db`) starts a ready-to-use database on your machine, with a health check so you know when it's actually ready.
- Data persists across restarts — stopping and starting the database doesn't wipe what's in it.
- A `.env.example` file documents the one setting (a password) needed to run it locally; the real `.env` is kept out of git.
- `CLAUDE.md` updated with the new command.

## Test plan
- [x] `docker compose up db` starts and reports healthy
- [x] Data survives a `docker compose down && docker compose up db` cycle (verified by writing then re-reading a test row)
- [x] PostGIS extension is available (`SELECT postgis_version();`)
- [x] `.env` confirmed gitignored
- [x] Reviewed by a second pass for correctness/simplification — no issues found

Part of the Epic 1 (persistence foundations) work described in `docs/planning/epics.md`.