### PR TITLE
Add the map data table to the database

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,7 +39,7 @@ docker compose up db       # starts a PostGIS 16-3.4 container on localhost:5432
 cd db/Migrations
 dotnet ef database update   # applies pending EF Core migrations to the `db` service
 ```
-Run from `db/Migrations/` (the project directory) with the `db` service up and `POSTGRES_PASSWORD` set in the environment (`db/Migrations` reads it the same way docker-compose does — see `db/Migrations/README.md`). This is a minimal class library that exists only to host EF Core migration tooling (`BikeMapDbContext`) ahead of the future `api/` project — see `db/Migrations/README.md` for why it's scaffolded separately and early. It currently has no entities registered; story 1.6 adds the `features` entity mapping.
+Run from `db/Migrations/` (the project directory) with the `db` service up and `POSTGRES_PASSWORD` set in the environment (`db/Migrations` reads it the same way docker-compose does — see `db/Migrations/README.md`). This is a minimal class library that exists only to host EF Core migration tooling (`BikeMapDbContext`) ahead of the future `api/` project — see `db/Migrations/README.md` for why it's scaffolded separately and early. `BikeMapDbContext` registers one entity, `Feature` (table `features`, mapped to `docs/planning/layers/persistence-layer.md` §1.1) — `feature_type` is a real Postgres enum (`feature_type_enum`), mapped to the `FeatureType` C# enum via Npgsql's `HasPostgresEnum`/`MapEnum`.
 
 There is no test suite for either the frontend or the pipeline.
 

--- a/db/Migrations/BikeMapDbContext.cs
+++ b/db/Migrations/BikeMapDbContext.cs
@@ -3,10 +3,10 @@ using Microsoft.EntityFrameworkCore;
 namespace BikeMap.Migrations;
 
 /// <summary>
-/// EF Core context for the `bikemap` PostGIS database. Intentionally has zero
-/// entities registered as of story 1.5 — this project exists only to host EF
-/// Core migration tooling ahead of the `features` entity mapping (story 1.6)
-/// and the future `api/` project. See db/Migrations/README.md.
+/// EF Core context for the `bikemap` PostGIS database. Story 1.5 scaffolded
+/// this with zero entities; story 1.6 adds the `features` table mapping —
+/// see docs/planning/layers/persistence-layer.md §1.1 for the authoritative
+/// schema.
 /// </summary>
 public class BikeMapDbContext : DbContext
 {
@@ -15,12 +15,92 @@ public class BikeMapDbContext : DbContext
     {
     }
 
+    public DbSet<Feature> Features => Set<Feature>();
+
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
         base.OnModelCreating(modelBuilder);
 
-        // Story 1.6 adds the `features` entity mapping (and the
-        // `feature_type_enum` Postgres enum via HasPostgresEnum<FeatureType>())
-        // here. Nothing is registered yet, by design.
+        // `feature_type` is a real Postgres ENUM, not TEXT+CHECK — see
+        // persistence-layer.md §1.3/§9. Npgsql maps the Postgres enum type
+        // directly to the FeatureType C# enum.
+        modelBuilder.HasPostgresEnum<FeatureType>(name: "feature_type_enum");
+
+        modelBuilder.Entity<Feature>(entity =>
+        {
+            entity.ToTable("features", t =>
+            {
+                t.HasCheckConstraint(
+                    "features_osm_type_check",
+                    "osm_type IN ('way', 'relation')");
+                t.HasCheckConstraint("chk_features_geom_valid", "ST_IsValid(geom)");
+                t.HasCheckConstraint(
+                    "chk_features_geom_type",
+                    "GeometryType(geom) IN ('LINESTRING', 'MULTILINESTRING')");
+            });
+
+            entity.HasKey(f => f.Id);
+            entity.Property(f => f.Id).HasColumnName("id").UseIdentityByDefaultColumn();
+
+            entity.Property(f => f.OsmType)
+                .HasColumnName("osm_type")
+                .HasColumnType("text")
+                .IsRequired();
+            entity.Property(f => f.OsmId).HasColumnName("osm_id").IsRequired();
+
+            entity.Property(f => f.FeatureType).HasColumnName("feature_type").IsRequired();
+
+            // geometry(Geometry, 4326) — deliberately the NTS base Geometry
+            // type, not narrowed to LineString/MultiLineString; see Feature.cs.
+            entity.Property(f => f.Geom)
+                .HasColumnName("geom")
+                .HasColumnType("geometry(Geometry, 4326)")
+                .IsRequired();
+
+            entity.Property(f => f.CyclewayLeft).HasColumnName("cycleway_left");
+            entity.Property(f => f.CyclewayRight).HasColumnName("cycleway_right");
+            entity.Property(f => f.CyclewayLeftBuffer)
+                .HasColumnName("cycleway_left_buffer")
+                .HasDefaultValue(false)
+                .IsRequired();
+            entity.Property(f => f.CyclewayRightBuffer)
+                .HasColumnName("cycleway_right_buffer")
+                .HasDefaultValue(false)
+                .IsRequired();
+
+            entity.Property(f => f.Bicycle).HasColumnName("bicycle");
+
+            entity.Property(f => f.Route).HasColumnName("route");
+            entity.Property(f => f.CycleNetwork).HasColumnName("cycle_network");
+            entity.Property(f => f.Ref).HasColumnName("ref");
+            entity.Property(f => f.Name).HasColumnName("name");
+            entity.Property(f => f.State).HasColumnName("state");
+
+            entity.Property(f => f.Tags)
+                .HasColumnName("tags")
+                .HasColumnType("jsonb")
+                .HasDefaultValueSql("'{}'::jsonb")
+                .IsRequired();
+
+            entity.Property(f => f.FirstSeenAt)
+                .HasColumnName("first_seen_at")
+                .HasDefaultValueSql("now()")
+                .IsRequired();
+            entity.Property(f => f.LastSeenAt)
+                .HasColumnName("last_seen_at")
+                .HasDefaultValueSql("now()")
+                .IsRequired();
+
+            entity.HasIndex(f => new { f.OsmType, f.OsmId })
+                .IsUnique()
+                .HasDatabaseName("ux_features_osm_key");
+
+            entity.HasIndex(f => f.Geom)
+                .HasDatabaseName("idx_features_geom")
+                .HasMethod("GIST");
+
+            entity.HasIndex(f => f.FeatureType)
+                .HasDatabaseName("idx_features_feature_type");
+        });
     }
 }

--- a/db/Migrations/DesignTimeDbContextFactory.cs
+++ b/db/Migrations/DesignTimeDbContextFactory.cs
@@ -54,8 +54,13 @@ public class DesignTimeDbContextFactory : IDesignTimeDbContextFactory<BikeMapDbC
             connectionString = builder.ConnectionString;
         }
 
+        var dataSourceBuilder = new NpgsqlDataSourceBuilder(connectionString);
+        dataSourceBuilder.UseNetTopologySuite();
+        dataSourceBuilder.MapEnum<FeatureType>("feature_type_enum");
+        var dataSource = dataSourceBuilder.Build();
+
         var optionsBuilder = new DbContextOptionsBuilder<BikeMapDbContext>();
-        optionsBuilder.UseNpgsql(connectionString, o => o.UseNetTopologySuite());
+        optionsBuilder.UseNpgsql(dataSource, o => o.UseNetTopologySuite());
 
         return new BikeMapDbContext(optionsBuilder.Options);
     }

--- a/db/Migrations/Feature.cs
+++ b/db/Migrations/Feature.cs
@@ -1,0 +1,53 @@
+using NetTopologySuite.Geometries;
+
+namespace BikeMap.Migrations;
+
+/// <summary>
+/// One row per OSM element (way or relation) contributing cycling
+/// infrastructure — roads, paths, or route relations. See
+/// docs/planning/layers/persistence-layer.md §1.1 for the authoritative
+/// schema and rationale; this class and
+/// <see cref="BikeMapDbContext.OnModelCreating"/> together are the EF Core
+/// mapping of that schema. Property groups below correspond to the
+/// Contract A property families keyed off <see cref="FeatureType"/>.
+/// </summary>
+public class Feature
+{
+    public long Id { get; set; }
+
+    // Contract B natural key: identifies the source OSM element.
+    public string OsmType { get; set; } = null!;
+    public long OsmId { get; set; }
+
+    // Which Contract A property family this row feeds.
+    public FeatureType FeatureType { get; set; }
+
+    // WGS84 lon/lat. LineString for ways; MultiLineString for relations
+    // resolved from >1 disjoint member way. Mapped as the NTS base
+    // Geometry type (not LineString/MultiLineString) — see
+    // persistence-layer.md §1.1's note on chk_features_geom_type.
+    public Geometry Geom { get; set; } = null!;
+
+    // --- Roads (feature_type = 'road') ---
+    public string? CyclewayLeft { get; set; }
+    public string? CyclewayRight { get; set; }
+    public bool CyclewayLeftBuffer { get; set; }
+    public bool CyclewayRightBuffer { get; set; }
+
+    // --- Paths (feature_type = 'path') ---
+    public string? Bicycle { get; set; }
+
+    // --- Routes (feature_type = 'route') ---
+    public string? Route { get; set; }
+    public string? CycleNetwork { get; set; }
+    public string? Ref { get; set; }
+    public string? Name { get; set; }
+    public string? State { get; set; }
+
+    // Full raw OSM tag bag, unfiltered.
+    public string Tags { get; set; } = "{}";
+
+    // Ingestion bookkeeping.
+    public DateTimeOffset FirstSeenAt { get; set; }
+    public DateTimeOffset LastSeenAt { get; set; }
+}

--- a/db/Migrations/FeatureType.cs
+++ b/db/Migrations/FeatureType.cs
@@ -1,0 +1,19 @@
+namespace BikeMap.Migrations;
+
+/// <summary>
+/// Mirrors the Postgres <c>feature_type_enum</c> type (see
+/// docs/planning/layers/persistence-layer.md §1.1/§1.3/§9). Distinguishes
+/// which Contract A property family a <see cref="Feature"/> row feeds:
+/// roads (cycleway_left/right etc.), paths (bicycle designation), or route
+/// relations (route/cycle_network/ref/name/state). Mapped to the Postgres
+/// enum via <c>HasPostgresEnum&lt;FeatureType&gt;()</c> in
+/// <see cref="BikeMapDbContext.OnModelCreating"/>, which is a real
+/// classification with no OSM-native equivalent — not a passthrough of an
+/// existing OSM tag value, hence a proper enum type rather than TEXT+CHECK.
+/// </summary>
+public enum FeatureType
+{
+    Road,
+    Path,
+    Route,
+}

--- a/db/Migrations/Migrations/20260817061707_AddFeaturesTable.Designer.cs
+++ b/db/Migrations/Migrations/20260817061707_AddFeaturesTable.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using BikeMap.Migrations;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NetTopologySuite.Geometries;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
@@ -12,9 +13,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Migrations.Migrations
 {
     [DbContext(typeof(BikeMapDbContext))]
-    partial class BikeMapDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260817061707_AddFeaturesTable")]
+    partial class AddFeaturesTable
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/db/Migrations/Migrations/20260817061707_AddFeaturesTable.cs
+++ b/db/Migrations/Migrations/20260817061707_AddFeaturesTable.cs
@@ -1,0 +1,84 @@
+﻿using System;
+using BikeMap.Migrations;
+using Microsoft.EntityFrameworkCore.Migrations;
+using NetTopologySuite.Geometries;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+
+#nullable disable
+
+namespace Migrations.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddFeaturesTable : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterDatabase()
+                .Annotation("Npgsql:Enum:feature_type_enum", "road,path,route")
+                .Annotation("Npgsql:PostgresExtension:postgis", ",,")
+                .OldAnnotation("Npgsql:PostgresExtension:postgis", ",,");
+
+            migrationBuilder.CreateTable(
+                name: "features",
+                columns: table => new
+                {
+                    id = table.Column<long>(type: "bigint", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    osm_type = table.Column<string>(type: "text", nullable: false),
+                    osm_id = table.Column<long>(type: "bigint", nullable: false),
+                    feature_type = table.Column<FeatureType>(type: "feature_type_enum", nullable: false),
+                    geom = table.Column<Geometry>(type: "geometry(Geometry, 4326)", nullable: false),
+                    cycleway_left = table.Column<string>(type: "text", nullable: true),
+                    cycleway_right = table.Column<string>(type: "text", nullable: true),
+                    cycleway_left_buffer = table.Column<bool>(type: "boolean", nullable: false, defaultValue: false),
+                    cycleway_right_buffer = table.Column<bool>(type: "boolean", nullable: false, defaultValue: false),
+                    bicycle = table.Column<string>(type: "text", nullable: true),
+                    route = table.Column<string>(type: "text", nullable: true),
+                    cycle_network = table.Column<string>(type: "text", nullable: true),
+                    @ref = table.Column<string>(name: "ref", type: "text", nullable: true),
+                    name = table.Column<string>(type: "text", nullable: true),
+                    state = table.Column<string>(type: "text", nullable: true),
+                    tags = table.Column<string>(type: "jsonb", nullable: false, defaultValueSql: "'{}'::jsonb"),
+                    first_seen_at = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false, defaultValueSql: "now()"),
+                    last_seen_at = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false, defaultValueSql: "now()")
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_features", x => x.id);
+                    table.CheckConstraint("chk_features_geom_type", "GeometryType(geom) IN ('LINESTRING', 'MULTILINESTRING')");
+                    table.CheckConstraint("chk_features_geom_valid", "ST_IsValid(geom)");
+                    table.CheckConstraint("features_osm_type_check", "osm_type IN ('way', 'relation')");
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "idx_features_feature_type",
+                table: "features",
+                column: "feature_type");
+
+            migrationBuilder.CreateIndex(
+                name: "idx_features_geom",
+                table: "features",
+                column: "geom")
+                .Annotation("Npgsql:IndexMethod", "GIST");
+
+            migrationBuilder.CreateIndex(
+                name: "ux_features_osm_key",
+                table: "features",
+                columns: new[] { "osm_type", "osm_id" },
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "features");
+
+            migrationBuilder.AlterDatabase()
+                .Annotation("Npgsql:PostgresExtension:postgis", ",,")
+                .OldAnnotation("Npgsql:Enum:feature_type_enum", "road,path,route")
+                .OldAnnotation("Npgsql:PostgresExtension:postgis", ",,");
+        }
+    }
+}

--- a/db/Migrations/README.md
+++ b/db/Migrations/README.md
@@ -15,10 +15,19 @@ types a future ASP.NET Core API project will also use for the same tables
 `dotnet ef` needs a .NET project to run against, but the full `api/`
 project (Epic 2) doesn't exist yet — building it out just to unblock
 schema migrations would be backwards. So this project scaffolds *only*
-what `dotnet ef` needs: package references, an (initially empty)
-`BikeMapDbContext`, and a design-time factory. It is deliberately not a
-web project and has no entities registered yet — story 1.6 adds the
-`features` entity mapping here.
+what `dotnet ef` needs: package references, a `BikeMapDbContext`, and a
+design-time factory. It is deliberately not a web project.
+
+Story 1.6 added the first entity, `Feature` (`Feature.cs`, table
+`features`) — see `docs/planning/layers/persistence-layer.md` §1.1 for the
+authoritative schema. `feature_type` is a real Postgres enum
+(`feature_type_enum`, `FeatureType.cs`), not TEXT+CHECK; it's registered
+via `modelBuilder.HasPostgresEnum<FeatureType>(name: "feature_type_enum")`
+in `BikeMapDbContext.OnModelCreating` for migration DDL generation, and via
+`NpgsqlDataSourceBuilder.MapEnum<FeatureType>("feature_type_enum")` in
+`DesignTimeDbContextFactory` so `dotnet ef` actually maps the CLR enum to
+the Postgres type instead of a plain integer column. A future `api/`
+project's own connection setup will need the same `MapEnum` registration.
 
 Once Epic 2 stands up `api/Api.csproj`, that project can reference this one
 (or this one's contents can be absorbed into it) without a disruptive move


### PR DESCRIPTION
## Summary
Creates the actual database table (`features`) that will hold all the bike lane, path, and route data going forward — the core piece of the new database-backed setup. Every road, path, and route in the map will eventually live here as one row, instead of a single flat file.

## What this gives us
- A `features` table that can hold roads, paths, and bike routes together, with the right fields for each type (e.g. bike lane style for roads, designation for paths, route name/network for routes).
- Guardrails built into the database itself: it rejects broken/invalid map geometry, rejects duplicate entries for the same OSM source data, and only allows valid category values (road/path/route) — so bad data can't sneak in silently.
- Indexed for fast "what's in this area of the map" lookups, which is what the future API will rely on.
- Confirmed the whole thing can be built from scratch reliably (tear it down, rebuild it, get the same result every time).

## Test plan
- [x] Table and all constraints/indexes created exactly as designed, verified directly against the database
- [x] Invalid map geometry is rejected
- [x] Wrong geometry type (a single point instead of a line) is rejected
- [x] Duplicate entries are rejected
- [x] Invalid category values are rejected
- [x] Rebuilding from empty reproduces an identical result
- [x] Reviewed by a second pass; one flagged concern was investigated and confirmed to be a false alarm (re-verified live against a fresh database)

Stacked on #43 (migrations tooling) → #42 (local database). Part of the Epic 1 (persistence foundations) work described in `docs/planning/epics.md`.